### PR TITLE
Add scp post config support

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Checkout the repository
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.GITHUB_REF }}
 
       - name: Get Add-on Release
         uses: KJ002/read-yaml@v1.4

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Checkout the repository
         uses: actions/checkout@v2
-        with:
-          ref: main
 
       - name: Get Add-on Release
         uses: KJ002/read-yaml@v1.4

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:12.2.2
-  amd64: ghcr.io/hassio-addons/base/amd64:12.2.2
-  armhf: ghcr.io/hassio-addons/base/armhf:12.2.2
-  armv7: ghcr.io/hassio-addons/base/armv7:12.2.2
-  i386: ghcr.io/hassio-addons/base/i386:12.2.2
+  aarch64: ghcr.io/hassio-addons/base/aarch64:11.0.1
+  amd64: ghcr.io/hassio-addons/base/amd64:11.0.1
+  armhf: ghcr.io/hassio-addons/base/armhf:11.0.1
+  armv7: ghcr.io/hassio-addons/base/armv7:11.0.1
+  i386: ghcr.io/hassio-addons/base/i386:11.0.1

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:11.0.1
-  amd64: ghcr.io/hassio-addons/base/amd64:11.0.1
-  armhf: ghcr.io/hassio-addons/base/armhf:11.0.1
-  armv7: ghcr.io/hassio-addons/base/armv7:11.0.1
-  i386: ghcr.io/hassio-addons/base/i386:11.0.1
+  aarch64: ghcr.io/hassio-addons/base/aarch64:12.2.2
+  amd64: ghcr.io/hassio-addons/base/amd64:12.2.2
+  armhf: ghcr.io/hassio-addons/base/armhf:12.2.2
+  armv7: ghcr.io/hassio-addons/base/armv7:12.2.2
+  i386: ghcr.io/hassio-addons/base/i386:12.2.2

--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ schema:
   sslFromAsusRouter:
     routerUser: str
     routerIp: str
-    routerSshPort: integer
+    routerSshPort: int
     rsaPrivateKeyPath: str
     keyFilePathOnRouter: str
     certFilePathOnRouter: str

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: "Refresh SSL Cert From Asus DDNS Router"
-version: 0.0.3-dev
+version: 0.0.3-alpha
 slug: "refresher_ssl_cert_from_asus_ddns_router"
 description: "An Add-on that help refresh the SSL certificate under the /SSL folder from Asus Router DDNS"
 startup: once

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: "Refresh SSL Cert From Asus DDNS Router"
-version: 0.0.3-alpha
+version: 0.0.3
 slug: "refresher_ssl_cert_from_asus_ddns_router"
 description: "An Add-on that help refresh the SSL certificate under the /SSL folder from Asus Router DDNS"
 startup: once

--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ options:
   sslFromAsusRouter:
     routerUser: null
     routerIp: null
+    routerSshPort: 22
     rsaPrivateKeyPath: null
     keyFilePathOnRouter: null
     certFilePathOnRouter: null
@@ -26,6 +27,7 @@ schema:
   sslFromAsusRouter:
     routerUser: str
     routerIp: str
+    routerSshPort: integer
     rsaPrivateKeyPath: str
     keyFilePathOnRouter: str
     certFilePathOnRouter: str

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: "Refresh SSL Cert From Asus DDNS Router"
-version: 0.0.2
+version: 0.0.3-dev
 slug: "refresher_ssl_cert_from_asus_ddns_router"
 description: "An Add-on that help refresh the SSL certificate under the /SSL folder from Asus Router DDNS"
 startup: once

--- a/run.sh
+++ b/run.sh
@@ -40,5 +40,5 @@ chmod 644 ${SSH_DIR}/known_hosts;
 cat ${SSH_DIR}/known_hosts
 
 echo "scping..."
-scp -v ${ROUTER_USER}@${ROUTER_IP}:${KEY_PATH_ON_ROUTER} /ssl/
-scp -v ${ROUTER_USER}@${ROUTER_IP}:${CERT_PATH_ON_ROUTER} /ssl/
+scp -P $(bashio::config 'sslFromAsusRouter.routerSshPort') -v ${ROUTER_USER}@${ROUTER_IP}:${KEY_PATH_ON_ROUTER} /ssl/
+scp -P $(bashio::config 'sslFromAsusRouter.routerSshPort') -v ${ROUTER_USER}@${ROUTER_IP}:${CERT_PATH_ON_ROUTER} /ssl/


### PR DESCRIPTION
Thanks to suggestion from @blugemni on the homeassistant forum, now this version has the following new feature

- Can configurate ports used for scp